### PR TITLE
Online user data-cors

### DIFF
--- a/backend/src/main/java/org/http/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/http/backend/config/SecurityConfig.java
@@ -4,15 +4,20 @@ import org.http.backend.component.CustomFormLoginSuccessHandler;
 import org.http.backend.component.CustomOAuth2SuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
@@ -25,9 +30,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(auth -> {
+        http.cors(Customizer.withDefaults()).csrf(AbstractHttpConfigurer::disable).authorizeHttpRequests(auth -> {
                     auth.requestMatchers(("/admin")).hasRole("ADMIN");
-                    //auth.requestMatchers("/bookings").authenticated();
+                    auth.requestMatchers("/users/data").authenticated();
                     auth.requestMatchers("/movies/**", "/movies","/users", "/bookings", "/schedules/**", "/schedules", "/cinemas","/cinemas/**").permitAll();
                     auth.anyRequest().denyAll();
                 })
@@ -37,6 +42,20 @@ public class SecurityConfig {
                 .formLogin(form -> form
                         .successHandler(customFormLoginSuccessHandler));
         return http.build();
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:5174")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowCredentials(true)
+                        .allowedHeaders("*");
+            }
+        };
     }
 
     @Bean

--- a/backend/src/main/java/org/http/backend/controller/BookingController.java
+++ b/backend/src/main/java/org/http/backend/controller/BookingController.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-@CrossOrigin(origins = "http://localhost:5174")
 @RestController
 @RequestMapping("/bookings")
 public class BookingController {

--- a/backend/src/main/java/org/http/backend/controller/CinemaController.java
+++ b/backend/src/main/java/org/http/backend/controller/CinemaController.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/cinemas")
-@CrossOrigin(origins = "http://localhost:5174")
 public class CinemaController {
 
     private final CinemaService cinemaService;

--- a/backend/src/main/java/org/http/backend/controller/MovieController.java
+++ b/backend/src/main/java/org/http/backend/controller/MovieController.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/movies")
-@CrossOrigin(origins = "http://localhost:5174")
 public class MovieController {
     private final MovieService movieService;
 

--- a/backend/src/main/java/org/http/backend/controller/ScheduleController.java
+++ b/backend/src/main/java/org/http/backend/controller/ScheduleController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "http://localhost:5174")
 @RestController
 @RequestMapping("/schedules")
 public class ScheduleController {

--- a/backend/src/main/java/org/http/backend/controller/UserController.java
+++ b/backend/src/main/java/org/http/backend/controller/UserController.java
@@ -3,7 +3,11 @@ package org.http.backend.controller;
 import org.http.backend.entity.User;
 import org.http.backend.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.*;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @RestController
@@ -23,6 +27,23 @@ public class UserController {
     @PostMapping
     public ResponseEntity<User> save(@RequestBody User user) {
         return ResponseEntity.ok().body(userService.save(user));
+    }
+
+    @GetMapping("/data")
+    public ResponseEntity<Map<String,String>> loggedInUserData(Authentication authentication) {
+        if (authentication == null)
+            return ResponseEntity.badRequest().build();
+        Map <String, String> data = new HashMap<>();
+        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+
+        String googleId = oidcUser.getSubject();
+        String email = oidcUser.getEmail();
+        String name = oidcUser.getFullName();
+
+        data.put("googleId", googleId);
+        data.put("email", email);
+        data.put("name", name);
+        return ResponseEntity.ok(data);
     }
 
 }


### PR DESCRIPTION
Endpoint to fetch the data of online user. 
Added global cors handling due to the problems that happened when a signed in user sent a request like the one below:

fetch('https://example.com/api/data', {
    method: 'GET'
    credentials: 'include', 
})

