### PR TITLE
Add backdrop to movie profile and in db

### DIFF
--- a/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
+++ b/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
@@ -18,79 +18,79 @@ public class DbInitDummyData {
             movieRepository.deleteAll();
             Movie[] movies = new Movie[]{
                     new Movie("238", "The Godfather", "Spanning the years 1945 to 1955, a chronicle of the fictional Italian-American Corleone crime family. When organized crime family patriarch, Vito Corleone barely survives an attempt on his life, his youngest son, Michael steps in to take care of the would-be killers, launching a campaign of bloody revenge.",
-                            Arrays.asList("Drama", "Crime"), "175", "1972-03-14", "/3bhkrj58Vtu7enYsRolD1fZdja1.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Crime"), "175", "1972-03-14", "/3bhkrj58Vtu7enYsRolD1fZdja1.jpg", Collections.emptyList(), "/ejdD20cdHNFAYAN2DlqPToXKyzx.jpg"),
 
                     new Movie("278", "The Shawshank Redemption", "Imprisoned in the 1940s for the double murder of his wife and her lover, upstanding banker Andy Dufresne begins a new life at the Shawshank prison, where he puts his accounting skills to work for an amoral warden. During his long stretch in prison, Dufresne comes to be admired by the other inmates -- including an older prisoner named Red -- for his integrity and unquenchable sense of hope.",
-                            Arrays.asList("Drama", "Crime"), "142", "1994-09-23", "/9cqNxx0GxF0bflZmeSMuL5tnGzr.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Crime"), "142", "1994-09-23", "/9cqNxx0GxF0bflZmeSMuL5tnGzr.jpg", Collections.emptyList(),"/zfbjgQE1uSd9wiPTX4VzsLi0rGG.jpg" ),
 
                     new Movie("240", "The Godfather Part II", "In the continuing saga of the Corleone crime family, a young Vito Corleone grows up in Sicily and in 1910s New York. In the 1950s, Michael Corleone attempts to expand the family business into Las Vegas, Hollywood and Cuba.",
-                            Arrays.asList("Drama", "Crime"), "202", "1974-12-20", "/hek3koDUyRQk7FIhPXsa6mT2Zc3.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Crime"), "202", "1974-12-20", "/hek3koDUyRQk7FIhPXsa6mT2Zc3.jpg", Collections.emptyList(),"/kGzFbGhp99zva6oZODW5atUtnqi.jpg"),
 
                     new Movie("424", "Schindler's List", "The true story of how businessman Oskar Schindler saved over a thousand Jewish lives from the Nazis while they worked as slaves in his factory during World War II.",
-                            Arrays.asList("Drama", "History", "War"), "195", "1993-12-15", "/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "History", "War"), "195", "1993-12-15", "/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg", Collections.emptyList(), "/yPisjyLweCl1tbgwgtzBCNCBle.jpg"),
 
                     new Movie("389", "12 Angry Men", "The defense and the prosecution have rested and the jury is filing into the jury room to decide if a young Spanish-American is guilty or innocent of murdering his father. What begins as an open and shut case soon becomes a mini-drama of each of the jurors' prejudices and preconceptions about the trial, the accused, and each other.",
-                            Collections.singletonList("Drama"), "97", "1957-04-10", "/ow3wq89wM8qd5X7hWKxiRfsFf9C.jpg", Collections.emptyList()),
+                            Collections.singletonList("Drama"), "97", "1957-04-10", "/ow3wq89wM8qd5X7hWKxiRfsFf9C.jpg", Collections.emptyList(),"/3W0v956XxSG5xgm7LB6qu8ExYJ2.jpg"),
 
                     new Movie("129", "Spirited Away",
                             "A young girl, Chihiro, becomes trapped in a strange new world of spirits. When her parents undergo a mysterious transformation, she must call upon the courage she never knew she had to free her family.",
-                            Arrays.asList("Animation", "Family", "Fantasy"), "125", "2001-07-20", "/39wmItIWsg5sZMyRUHLkWBcuVCM.jpg", Collections.emptyList()),
+                            Arrays.asList("Animation", "Family", "Fantasy"), "125", "2001-07-20", "/39wmItIWsg5sZMyRUHLkWBcuVCM.jpg", Collections.emptyList(), "/mSDsSDwaP3E7dEfUPWy4J0djt4O.jpg"),
 
                     new Movie("19404", "Dilwale Dulhania Le Jayenge",
                             "Raj is a rich, carefree, happy-go-lucky second generation NRI. Simran is the daughter of Chaudhary Baldev Singh, who in spite of being an NRI is very strict about adherence to Indian values. Simran has left for India to be married to her childhood fiancé. Raj leaves for India with a mission at his hands, to claim his lady love under the noses of her whole family. Thus begins a saga.",
-                            Arrays.asList("Comedy", "Drama", "Romance"), "190", "1995-10-20", "/lfRkUr7DYdHldAqi3PwdQGBRBPM.jpg", Collections.emptyList()),
+                            Arrays.asList("Comedy", "Drama", "Romance"), "190", "1995-10-20", "/lfRkUr7DYdHldAqi3PwdQGBRBPM.jpg", Collections.emptyList() ,"/nl79FQ8xWZkhL3rDr1v2RFFR6J0.jpg"),
 
                     new Movie("155", "The Dark Knight",
                             "Batman raises the stakes in his war on crime. With the help of Lt. Jim Gordon and District Attorney Harvey Dent, Batman sets out to dismantle the remaining criminal organizations that plague the streets. The partnership proves to be effective, but they soon find themselves prey to a reign of chaos unleashed by a rising criminal mastermind known to the terrified citizens of Gotham as the Joker.",
-                            Arrays.asList("Drama", "Action", "Crime", "Thriller"), "152", "2008-07-16", "/qJ2tW6WMUDux911r6m7haRef0WH.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Action", "Crime", "Thriller"), "152", "2008-07-16", "/qJ2tW6WMUDux911r6m7haRef0WH.jpg", Collections.emptyList(), "/hkBaDkMWbLaf8B1lsWsKX7Ew3Xq.jpg"),
 
                     new Movie("496243", "Parasite",
                             "All unemployed, Ki-taek's family takes peculiar interest in the wealthy and glamorous Parks for their livelihood until they get entangled in an unexpected incident.",
-                            Arrays.asList("Comedy", "Thriller", "Drama"), "133", "2019-05-30", "/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg", Collections.emptyList()),
+                            Arrays.asList("Comedy", "Thriller", "Drama"), "133", "2019-05-30", "/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg", Collections.emptyList(), "/TU9NIjwzjoKPwQHoHshkFcQUCG.jpg"),
 
                     new Movie("497", "The Green Mile",
                             "A supernatural tale set on death row in a Southern prison, where gentle giant John Coffey possesses the mysterious power to heal people's ailments. When the cell block's head guard, Paul Edgecomb, recognizes Coffey's miraculous gift, he tries desperately to help stave off the condemned man's execution.",
-                            Arrays.asList("Fantasy", "Drama", "Crime"), "189", "1999-12-10", "/8VG8fDNiy50H4FedGwdSVUPoaJe.jpg", Collections.emptyList()),
+                            Arrays.asList("Fantasy", "Drama", "Crime"), "189", "1999-12-10", "/8VG8fDNiy50H4FedGwdSVUPoaJe.jpg", Collections.emptyList(), "/velWPhVMQeQKcxggNEU8YmIo52R.jpg"),
 
                     new Movie("680", "Pulp Fiction",
                             "A burger-loving hit man, his philosophical partner, a drug-addled gangster's moll and a washed-up boxer converge in this sprawling, comedic crime caper. Their adventures unfurl in three stories that ingeniously trip back and forth in time.",
-                            Arrays.asList("Thriller", "Crime"), "154", "1994-09-10", "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg", Collections.emptyList()),
+                            Arrays.asList("Thriller", "Crime"), "154", "1994-09-10", "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg", Collections.emptyList(), "/plnlrtBUULT0rh3Xsjmpubiso3L.jpg"),
 
                     new Movie("372058", "Your Name.",
                             "High schoolers Mitsuha and Taki are complete strangers living separate lives. But one night, they suddenly switch places. Mitsuha wakes up in Taki’s body, and he in hers. This bizarre occurrence continues to happen randomly, and the two must adjust their lives around each other.",
-                            Arrays.asList("Animation", "Romance", "Drama"), "106", "2016-08-26", "/vfJFJPepRKapMd5G2ro7klIRysq.jpg", Collections.emptyList()),
+                            Arrays.asList("Animation", "Romance", "Drama"), "106", "2016-08-26", "/vfJFJPepRKapMd5G2ro7klIRysq.jpg", Collections.emptyList(), "/mMtUybQ6hL24FXo0F3Z4j2KG7kZ.jpg"),
 
                     new Movie("122", "The Lord of the Rings: The Return of the King",
                             "As armies mass for a final battle that will decide the fate of the world--and powerful, ancient forces of Light and Dark compete to determine the outcome--one member of the Fellowship of the Ring is revealed as the noble heir to the throne of the Kings of Men. Yet, the sole hope for triumph over evil lies with a brave hobbit, Frodo, who, accompanied by his loyal friend Sam and the hideous, wretched Gollum, ventures deep into the very dark heart of Mordor on his seemingly impossible quest to destroy the Ring of Power.​",
-                            Arrays.asList("Adventure", "Fantasy", "Action"), "201", "2003-12-17", "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg", Collections.emptyList()),
+                            Arrays.asList("Adventure", "Fantasy", "Action"), "201", "2003-12-17", "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg", Collections.emptyList(), "/9zRzFJuaj0CHIOhAkc6v6pua9p1.jpg"),
 
                     new Movie("13", "Forrest Gump",
                             "A man with a low IQ has accomplished great things in his life and been present during significant historic events—in each case, far exceeding what anyone imagined he could do. But despite all he has achieved, his one true love eludes him.",
-                            Arrays.asList("Comedy", "Drama", "Romance"), "142", "1994-06-23", "/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg", Collections.emptyList()),
+                            Arrays.asList("Comedy", "Drama", "Romance"), "142", "1994-06-23", "/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg", Collections.emptyList(), "/yE5d3BUhE8hCnkMUJOo1QDoOGNz.jpg"),
 
                     new Movie("429", "The Good, the Bad and the Ugly",
                             "While the Civil War rages on between the Union and the Confederacy, three men – a quiet loner, a ruthless hitman, and a Mexican bandit – comb the American Southwest in search of a strongbox containing $200,000 in stolen gold.",
-                            Collections.singletonList("Western"), "161", "1966-12-22", "/bX2xnavhMYjWDoZp1VM6VnU1xwe.jpg", Collections.emptyList()),
+                            Collections.singletonList("Western"), "161", "1966-12-22", "/bX2xnavhMYjWDoZp1VM6VnU1xwe.jpg", Collections.emptyList(), "/f7DImXDebOs148U4uPjI61iDvaK.jpg"),
 
                     new Movie("769", "GoodFellas",
                             "The true story of Henry Hill, a half-Irish, half-Sicilian Brooklyn kid who is adopted by neighbourhood gangsters at an early age and climbs the ranks of a Mafia family under the guidance of Jimmy Conway.",
-                            Arrays.asList("Drama", "Crime"), "145", "1990-09-12", "/aKuFiU82s5ISJpGZp7YkIr3kCUd.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Crime"), "145", "1990-09-12", "/aKuFiU82s5ISJpGZp7YkIr3kCUd.jpg", Collections.emptyList(), "/7TF4p86ZafnxFuNqWdhpHXFO244.jpg"),
 
                     new Movie("346", "Seven Samurai",
                             "A samurai answers a village's request for protection after he falls on hard times. The town needs protection from bandits, so the samurai gathers six others to help him teach the people how to defend themselves, and the villagers provide the soldiers with food.",
-                            Arrays.asList("Action", "Drama"), "207", "1954-04-26", "/8OKmBV5BUFzmozIC3pPWKHy17kx.jpg", Collections.emptyList()),
+                            Arrays.asList("Action", "Drama"), "207", "1954-04-26", "/8OKmBV5BUFzmozIC3pPWKHy17kx.jpg", Collections.emptyList(), "/mMmp1j9qH9z4jv0QzZHa3Yv8CJ.jpg"),
 
                     new Movie("12477", "Grave of the Fireflies",
                             "In the final months of World War II, 14-year-old Seita and his sister Setsuko are orphaned when their mother is killed during an air raid in Kobe, Japan. After a falling out with their aunt, they move into an abandoned bomb shelter. With no surviving relatives and their emergency rations depleted, Seita and Setsuko struggle to survive.",
-                            Arrays.asList("Animation", "Drama", "War"), "89", "1988-04-16", "/k9tv1rXZbOhH7eiCk378x61kNQ1.jpg", Collections.emptyList()),
+                            Arrays.asList("Animation", "Drama", "War"), "89", "1988-04-16", "/k9tv1rXZbOhH7eiCk378x61kNQ1.jpg", Collections.emptyList(), "/4U7Q1bJG0R5h8eS8Yn8ZfFz8zvj.jpg"),
 
                     new Movie("11216", "Cinema Paradiso",
                             "A filmmaker recalls his childhood, when he fell in love with the movies at his village's theater and formed a deep friendship with the theater's projectionist.",
-                            Arrays.asList("Drama", "Romance"), "124", "1988-11-17", "/gCI2AeMV4IHSewhJkzsur5MEp6R.jpg", Collections.emptyList()),
+                            Arrays.asList("Drama", "Romance"), "124", "1988-11-17", "/gCI2AeMV4IHSewhJkzsur5MEp6R.jpg", Collections.emptyList(),"/7Qx2d8Z9Zz5T4Phd3t3G2Ma7R7U.jpg"),
 
                     new Movie("637", "Life Is Beautiful",
                             "A touching story of an Italian book seller of Jewish ancestry who lives in his own little fairy tale. His creative and happy life would come to an abrupt halt when his entire family is deported to a concentration camp during World War II. While locked up he tries to convince his son that the whole thing is just a game.",
-                            Arrays.asList("Comedy", "Drama"), "116", "1997-12-20", "/74hLDKjD5aGYOotO6esUVaeISa2.jpg", Collections.emptyList())
+                            Arrays.asList("Comedy", "Drama"), "116", "1997-12-20", "/74hLDKjD5aGYOotO6esUVaeISa2.jpg", Collections.emptyList(), "/bORe0eI72D874TMawOOFvqYgSE6.jpg"),
             };
             movieRepository.saveAll(Arrays.asList(movies));
         };

--- a/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
+++ b/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
@@ -27,10 +27,10 @@ public class DbInitDummyData {
                             Arrays.asList("Drama", "Crime"), "202", "1974-12-20", "/hek3koDUyRQk7FIhPXsa6mT2Zc3.jpg", Collections.emptyList(),"/kGzFbGhp99zva6oZODW5atUtnqi.jpg"),
 
                     new Movie("424", "Schindler's List", "The true story of how businessman Oskar Schindler saved over a thousand Jewish lives from the Nazis while they worked as slaves in his factory during World War II.",
-                            Arrays.asList("Drama", "History", "War"), "195", "1993-12-15", "/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg", Collections.emptyList(), "/yPisjyLweCl1tbgwgtzBCNCBle.jpg"),
+                            Arrays.asList("Drama", "History", "War"), "195", "1993-12-15", "/sF1U4EUQS8YHUYjNl3pMGNIQyr0.jpg", Collections.emptyList(), "/zb6fM1CX41D9rF9hdgclu0peUmy.jpg"),
 
                     new Movie("389", "12 Angry Men", "The defense and the prosecution have rested and the jury is filing into the jury room to decide if a young Spanish-American is guilty or innocent of murdering his father. What begins as an open and shut case soon becomes a mini-drama of each of the jurors' prejudices and preconceptions about the trial, the accused, and each other.",
-                            Collections.singletonList("Drama"), "97", "1957-04-10", "/ow3wq89wM8qd5X7hWKxiRfsFf9C.jpg", Collections.emptyList(),"/3W0v956XxSG5xgm7LB6qu8ExYJ2.jpg"),
+                            Collections.singletonList("Drama"), "97", "1957-04-10", "/ow3wq89wM8qd5X7hWKxiRfsFf9C.jpg", Collections.emptyList(),"/qqHQsStV6exghCM7zbObuYBiYxw.jpg"),
 
                     new Movie("129", "Spirited Away",
                             "A young girl, Chihiro, becomes trapped in a strange new world of spirits. When her parents undergo a mysterious transformation, she must call upon the courage she never knew she had to free her family.",
@@ -38,15 +38,15 @@ public class DbInitDummyData {
 
                     new Movie("19404", "Dilwale Dulhania Le Jayenge",
                             "Raj is a rich, carefree, happy-go-lucky second generation NRI. Simran is the daughter of Chaudhary Baldev Singh, who in spite of being an NRI is very strict about adherence to Indian values. Simran has left for India to be married to her childhood fiancé. Raj leaves for India with a mission at his hands, to claim his lady love under the noses of her whole family. Thus begins a saga.",
-                            Arrays.asList("Comedy", "Drama", "Romance"), "190", "1995-10-20", "/lfRkUr7DYdHldAqi3PwdQGBRBPM.jpg", Collections.emptyList() ,"/nl79FQ8xWZkhL3rDr1v2RFFR6J0.jpg"),
+                            Arrays.asList("Comedy", "Drama", "Romance"), "190", "1995-10-20", "/lfRkUr7DYdHldAqi3PwdQGBRBPM.jpg", Collections.emptyList() ,"/90ez6ArvpO8bvpyIngBuwXOqJm5.jpg"),
 
                     new Movie("155", "The Dark Knight",
                             "Batman raises the stakes in his war on crime. With the help of Lt. Jim Gordon and District Attorney Harvey Dent, Batman sets out to dismantle the remaining criminal organizations that plague the streets. The partnership proves to be effective, but they soon find themselves prey to a reign of chaos unleashed by a rising criminal mastermind known to the terrified citizens of Gotham as the Joker.",
-                            Arrays.asList("Drama", "Action", "Crime", "Thriller"), "152", "2008-07-16", "/qJ2tW6WMUDux911r6m7haRef0WH.jpg", Collections.emptyList(), "/hkBaDkMWbLaf8B1lsWsKX7Ew3Xq.jpg"),
+                            Arrays.asList("Drama", "Action", "Crime", "Thriller"), "152", "2008-07-16", "/qJ2tW6WMUDux911r6m7haRef0WH.jpg", Collections.emptyList(), "/nMKdUUepR0i5zn0y1T4CsSB5chy.jpg"),
 
                     new Movie("496243", "Parasite",
                             "All unemployed, Ki-taek's family takes peculiar interest in the wealthy and glamorous Parks for their livelihood until they get entangled in an unexpected incident.",
-                            Arrays.asList("Comedy", "Thriller", "Drama"), "133", "2019-05-30", "/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg", Collections.emptyList(), "/TU9NIjwzjoKPwQHoHshkFcQUCG.jpg"),
+                            Arrays.asList("Comedy", "Thriller", "Drama"), "133", "2019-05-30", "/7IiTTgloJzvGI1TAYymCfbfl3vT.jpg", Collections.emptyList(), "/8eihUxjQsJ7WvGySkVMC0EwbPAD.jpg"),
 
                     new Movie("497", "The Green Mile",
                             "A supernatural tale set on death row in a Southern prison, where gentle giant John Coffey possesses the mysterious power to heal people's ailments. When the cell block's head guard, Paul Edgecomb, recognizes Coffey's miraculous gift, he tries desperately to help stave off the condemned man's execution.",
@@ -62,15 +62,15 @@ public class DbInitDummyData {
 
                     new Movie("122", "The Lord of the Rings: The Return of the King",
                             "As armies mass for a final battle that will decide the fate of the world--and powerful, ancient forces of Light and Dark compete to determine the outcome--one member of the Fellowship of the Ring is revealed as the noble heir to the throne of the Kings of Men. Yet, the sole hope for triumph over evil lies with a brave hobbit, Frodo, who, accompanied by his loyal friend Sam and the hideous, wretched Gollum, ventures deep into the very dark heart of Mordor on his seemingly impossible quest to destroy the Ring of Power.​",
-                            Arrays.asList("Adventure", "Fantasy", "Action"), "201", "2003-12-17", "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg", Collections.emptyList(), "/9zRzFJuaj0CHIOhAkc6v6pua9p1.jpg"),
+                            Arrays.asList("Adventure", "Fantasy", "Action"), "201", "2003-12-17", "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg", Collections.emptyList(), "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg"),
 
                     new Movie("13", "Forrest Gump",
                             "A man with a low IQ has accomplished great things in his life and been present during significant historic events—in each case, far exceeding what anyone imagined he could do. But despite all he has achieved, his one true love eludes him.",
-                            Arrays.asList("Comedy", "Drama", "Romance"), "142", "1994-06-23", "/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg", Collections.emptyList(), "/yE5d3BUhE8hCnkMUJOo1QDoOGNz.jpg"),
+                            Arrays.asList("Comedy", "Drama", "Romance"), "142", "1994-06-23", "/arw2vcBveWOVZr6pxd9XTd1TdQa.jpg", Collections.emptyList(), "/ghgfzbEV7kbpbi1O8eIILKVXEA8.jpg"),
 
                     new Movie("429", "The Good, the Bad and the Ugly",
                             "While the Civil War rages on between the Union and the Confederacy, three men – a quiet loner, a ruthless hitman, and a Mexican bandit – comb the American Southwest in search of a strongbox containing $200,000 in stolen gold.",
-                            Collections.singletonList("Western"), "161", "1966-12-22", "/bX2xnavhMYjWDoZp1VM6VnU1xwe.jpg", Collections.emptyList(), "/f7DImXDebOs148U4uPjI61iDvaK.jpg"),
+                            Collections.singletonList("Western"), "161", "1966-12-22", "/bX2xnavhMYjWDoZp1VM6VnU1xwe.jpg", Collections.emptyList(), "/Adrip2Jqzw56KeuV2nAxucKMNXA.jpg"),
 
                     new Movie("769", "GoodFellas",
                             "The true story of Henry Hill, a half-Irish, half-Sicilian Brooklyn kid who is adopted by neighbourhood gangsters at an early age and climbs the ranks of a Mafia family under the guidance of Jimmy Conway.",
@@ -78,19 +78,19 @@ public class DbInitDummyData {
 
                     new Movie("346", "Seven Samurai",
                             "A samurai answers a village's request for protection after he falls on hard times. The town needs protection from bandits, so the samurai gathers six others to help him teach the people how to defend themselves, and the villagers provide the soldiers with food.",
-                            Arrays.asList("Action", "Drama"), "207", "1954-04-26", "/8OKmBV5BUFzmozIC3pPWKHy17kx.jpg", Collections.emptyList(), "/mMmp1j9qH9z4jv0QzZHa3Yv8CJ.jpg"),
+                            Arrays.asList("Action", "Drama"), "207", "1954-04-26", "/8OKmBV5BUFzmozIC3pPWKHy17kx.jpg", Collections.emptyList(), "/sJNNMCc6B7KZIY3LH3JMYJJNH5j.jpg"),
 
                     new Movie("12477", "Grave of the Fireflies",
                             "In the final months of World War II, 14-year-old Seita and his sister Setsuko are orphaned when their mother is killed during an air raid in Kobe, Japan. After a falling out with their aunt, they move into an abandoned bomb shelter. With no surviving relatives and their emergency rations depleted, Seita and Setsuko struggle to survive.",
-                            Arrays.asList("Animation", "Drama", "War"), "89", "1988-04-16", "/k9tv1rXZbOhH7eiCk378x61kNQ1.jpg", Collections.emptyList(), "/4U7Q1bJG0R5h8eS8Yn8ZfFz8zvj.jpg"),
+                            Arrays.asList("Animation", "Drama", "War"), "89", "1988-04-16", "/k9tv1rXZbOhH7eiCk378x61kNQ1.jpg", Collections.emptyList(), "/gwj4R8Uy1GwejKqfofREKI9Jh7L.jpg"),
 
                     new Movie("11216", "Cinema Paradiso",
                             "A filmmaker recalls his childhood, when he fell in love with the movies at his village's theater and formed a deep friendship with the theater's projectionist.",
-                            Arrays.asList("Drama", "Romance"), "124", "1988-11-17", "/gCI2AeMV4IHSewhJkzsur5MEp6R.jpg", Collections.emptyList(),"/7Qx2d8Z9Zz5T4Phd3t3G2Ma7R7U.jpg"),
+                            Arrays.asList("Drama", "Romance"), "124", "1988-11-17", "/gCI2AeMV4IHSewhJkzsur5MEp6R.jpg", Collections.emptyList(),"/7lyq8hK0MhPHpUXdnqbFvZYSfkk.jpg"),
 
                     new Movie("637", "Life Is Beautiful",
                             "A touching story of an Italian book seller of Jewish ancestry who lives in his own little fairy tale. His creative and happy life would come to an abrupt halt when his entire family is deported to a concentration camp during World War II. While locked up he tries to convince his son that the whole thing is just a game.",
-                            Arrays.asList("Comedy", "Drama"), "116", "1997-12-20", "/74hLDKjD5aGYOotO6esUVaeISa2.jpg", Collections.emptyList(), "/bORe0eI72D874TMawOOFvqYgSE6.jpg"),
+                            Arrays.asList("Comedy", "Drama"), "116", "1997-12-20", "/74hLDKjD5aGYOotO6esUVaeISa2.jpg", Collections.emptyList(), "/gavyCu1UaTaTNPsVaGXT6pe5u24.jpg"),
             };
             movieRepository.saveAll(Arrays.asList(movies));
         };

--- a/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
+++ b/backend/src/main/java/org/http/backend/config/DbInitDummyData.java
@@ -50,11 +50,11 @@ public class DbInitDummyData {
 
                     new Movie("497", "The Green Mile",
                             "A supernatural tale set on death row in a Southern prison, where gentle giant John Coffey possesses the mysterious power to heal people's ailments. When the cell block's head guard, Paul Edgecomb, recognizes Coffey's miraculous gift, he tries desperately to help stave off the condemned man's execution.",
-                            Arrays.asList("Fantasy", "Drama", "Crime"), "189", "1999-12-10", "/8VG8fDNiy50H4FedGwdSVUPoaJe.jpg", Collections.emptyList(), "/velWPhVMQeQKcxggNEU8YmIo52R.jpg"),
+                            Arrays.asList("Fantasy", "Drama", "Crime"), "189", "1999-12-10", "/8VG8fDNiy50H4FedGwdSVUPoaJe.jpg", Collections.emptyList(), "/vxJ08SvwomfKbpboCWynC3uqUg4.jpg"),
 
                     new Movie("680", "Pulp Fiction",
                             "A burger-loving hit man, his philosophical partner, a drug-addled gangster's moll and a washed-up boxer converge in this sprawling, comedic crime caper. Their adventures unfurl in three stories that ingeniously trip back and forth in time.",
-                            Arrays.asList("Thriller", "Crime"), "154", "1994-09-10", "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg", Collections.emptyList(), "/plnlrtBUULT0rh3Xsjmpubiso3L.jpg"),
+                            Arrays.asList("Thriller", "Crime"), "154", "1994-09-10", "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg", Collections.emptyList(), "/suaEOtk1N1sgg2MTM7oZd2cfVp3.jpg"),
 
                     new Movie("372058", "Your Name.",
                             "High schoolers Mitsuha and Taki are complete strangers living separate lives. But one night, they suddenly switch places. Mitsuha wakes up in Taki’s body, and he in hers. This bizarre occurrence continues to happen randomly, and the two must adjust their lives around each other.",

--- a/backend/src/main/java/org/http/backend/dto/MovieDto.java
+++ b/backend/src/main/java/org/http/backend/dto/MovieDto.java
@@ -7,7 +7,7 @@ import org.http.backend.util.Rating;
 import java.util.ArrayList;
 import java.util.List;
 
-public record MovieDto(String id, String title, String overview, String runtime, @JsonProperty("release_date") String releaseDate, @JsonProperty("poster_path") String posterPath, List<GenreDto> genres) {
+public record MovieDto(String id, String title, String overview, String runtime, @JsonProperty("release_date") String releaseDate, @JsonProperty("poster_path") String posterPath, List<GenreDto> genres, String backdropPath) {
     public MovieDto {
         if (genres == null) {
             genres = List.of();
@@ -25,6 +25,7 @@ public record MovieDto(String id, String title, String overview, String runtime,
         movie.setGenres(genres.stream().map(GenreDto::name).toList());
         List<Rating> ratings = new ArrayList<>();
         movie.setRating(ratings);
+        movie.setBackdropPath(backdropPath);
         return movie;
     }
 }

--- a/backend/src/main/java/org/http/backend/entity/Movie.java
+++ b/backend/src/main/java/org/http/backend/entity/Movie.java
@@ -18,8 +18,9 @@ public class Movie {
     private String releaseDate;
     private String imageUrl;
     private List<Rating> rating;
+    private String backdropPath;
 
-    public Movie(String id, String name, String description, List<String> genre, String duration, String releaseDate, String imageUrl, List<Rating> rating) {
+    public Movie(String id, String name, String description, List<String> genre, String duration, String releaseDate, String imageUrl, List<Rating> rating, String backdropPath) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -28,6 +29,7 @@ public class Movie {
         this.releaseDate = releaseDate;
         this.imageUrl = imageUrl;
         this.rating = rating;
+        this.backdropPath = backdropPath;
     }
 
     public Movie() {
@@ -97,5 +99,12 @@ public class Movie {
         this.rating = rating;
     }
 
+    public String getBackdropPath() {
+        return backdropPath;
+    }
+
+    public void setBackdropPath(String backdropPath) {
+        this.backdropPath = backdropPath;
+    }
 }
 

--- a/frontend/src/components/__tests__/LandingView.spec.js
+++ b/frontend/src/components/__tests__/LandingView.spec.js
@@ -1,13 +1,12 @@
 import { mount } from '@vue/test-utils'
-import { describe, test, expect, beforeEach } from "vitest";
-import { ref } from 'vue';
+import { describe, test, expect, beforeEach , vi} from "vitest";
 import LandingView from "@/views/LandingView.vue"
 import { RouterLinkStub } from '@vue/test-utils'
 
 describe('Make sure moviearray work and can be processed', () => {
     let wrapper;
 
-    const movieArr = ref([
+    const movieArr = [
         {
             "name": "The Matrix",
             "description": "A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.",
@@ -85,12 +84,18 @@ describe('Make sure moviearray work and can be processed', () => {
             "imageUrl": "/qJ2tW6WMUDux911r6m7haRef0WH.jpg",
             "rating": 65
         }
-    ]);
+    ];
 
     /*
       Load mock data before tests
     */
     beforeEach(() => {
+        global.fetch = vi.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve(movieArr),
+            })
+        );
+
         wrapper = mount(LandingView, {
             global: {
                 stubs: {
@@ -98,7 +103,6 @@ describe('Make sure moviearray work and can be processed', () => {
                 }
             }
         });
-        wrapper.vm.movies = movieArr.value;
     });
 
     test('Load props', () => {

--- a/frontend/src/components/__tests__/MovieProfileView.spec.js
+++ b/frontend/src/components/__tests__/MovieProfileView.spec.js
@@ -28,6 +28,10 @@ describe("MovieProfileView", () => {
           json: () => Promise.resolve(movie),
         })
     );
+
+    // Mock window.scrollTo
+    window.scrollTo = vi.fn();
+
     wrapper = mount(MovieProfileView, {
       props: {
         id: "1",

--- a/frontend/src/components/__tests__/MovieProfileView.spec.js
+++ b/frontend/src/components/__tests__/MovieProfileView.spec.js
@@ -16,8 +16,9 @@ describe("MovieProfileView", () => {
     ],
     duration: 148,
     releaseDate: "2010-07-16",
-    imageUrl: "/8ZTVqvKDQ8emSGUEMjsS4yHAwrp.jpg",
-    rating: 8.8
+    imageUrl: "/ljsZTbVsrQSqZgWeep2B1QiDKuh.jpg",
+    rating: 8.8,
+    backdropPath: "/8ZTVqvKDQ8emSGUEMjsS4yHAwrp.jpg",
   };
 
   beforeEach(() => {

--- a/frontend/src/views/MovieProfileView.vue
+++ b/frontend/src/views/MovieProfileView.vue
@@ -27,7 +27,11 @@ const formattedDuration = computed(() => {
   return `${hours}h ${minutes}min`;
 });
 
-onMounted(fetchMovie);
+onMounted(() => {
+  fetchMovie();
+  window.scrollTo(0, 0);
+});
+
 </script>
 
 <template>

--- a/frontend/src/views/MovieProfileView.vue
+++ b/frontend/src/views/MovieProfileView.vue
@@ -33,9 +33,9 @@ onMounted(fetchMovie);
 <template>
   <main
     :style="{ backgroundImage: `url(${backdropPath})` }"
-    class="bg-cover bg-center min-h-screen relative"
+    class="bg-cover bg-center min-h-screen bg-fixed relative"
   >
-    <div v-if="movie" class="absolute inset-0 bg-black opacity-10 z-1"></div>
+    <div v-if="movie" class="absolute inset-0 bg-black opacity-50 z-1"></div>
     <div v-if="movie" class="p-4 relative z-2">
       <div class="flex flex-col items-start justify-center mt-10">
         <div class="flex mb-2 mx-6 justify-center">

--- a/frontend/src/views/MovieProfileView.vue
+++ b/frontend/src/views/MovieProfileView.vue
@@ -10,14 +10,14 @@ const props = defineProps({
 });
 
 const movie = ref(null);
-const imageUrl = ref("");
+const backdropPath = ref("");
 
 const fetchMovie = async () => {
   const response = await fetch(`http://localhost:9000/movies/${props.id}`, {
     method: "GET",
   });
   movie.value = await response.json();
-  imageUrl.value = `https://image.tmdb.org/t/p/w500${movie.value.imageUrl}`;
+  backdropPath.value = `https://image.tmdb.org/t/p/w500${movie.value.backdropPath}`;
 };
 
 const formattedDuration = computed(() => {
@@ -32,7 +32,7 @@ onMounted(fetchMovie);
 
 <template>
   <main
-    :style="{ backgroundImage: `url(${imageUrl})` }"
+    :style="{ backgroundImage: `url(${backdropPath})` }"
     class="bg-cover bg-center min-h-screen relative"
   >
     <div v-if="movie" class="absolute inset-0 bg-black opacity-10 z-1"></div>


### PR DESCRIPTION
### Updates to Backend 
- Added `backdropPath` to `Movie` and `MovieDto` to provide an image for the backdrop in `MovieProfileView.vue`.
- Updated `DbInitDummyData` with correct `backdropPaths`.


### Updates to Frontend
- Updated `MovieProfileView.vue` to replace `imageURL` with `backdropPath`.
- Set `backgroundImage` to fixed relative and increased opacity on the black layer above to 50%.
- Added `scrollTo` function in `onMounted` hook to automatically scroll to the top when `MovieProfileView` loads.

### Updates to Tests
- Updated `MovieProfileView.spec.js` to include `backdropPath`.

