### PR TITLE
Show seats for schedule 

### DIFF
--- a/frontend/src/components/Schedules.vue
+++ b/frontend/src/components/Schedules.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import {onMounted, ref, computed} from "vue";
 
 const props = defineProps({
   movie: {
@@ -11,22 +11,44 @@ const props = defineProps({
 const schedules = ref([]);
 
 const fetchSchedules = async () => {
-
   try {
     const response = await fetch(`http://localhost:9000/schedules/movie/${props.movie.id}`);
-
     if (!response.ok) {
       throw new Error(`Failed to fetch schedules for movie with id ${props.movie.id}: ${response.statusText}`);
     }
-
     schedules.value = await response.json();
-
     alert("Fetched schedules: " + JSON.stringify(schedules.value));
-
   } catch (error) {
     console.error(`Error fetching schedules for movie with id ${props.movie?.id || "unknown"}`, error);
   }
 };
+
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+  });
+};
+
+const formatTime = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const groupedSchedules = computed(() => {
+  return schedules.value.reduce((grouped, schedule) => {
+    const cinemaName = schedule.cinema.name;
+    if (!grouped[cinemaName]) {
+      grouped[cinemaName] = [];
+    }
+    grouped[cinemaName].push(schedule);
+    return grouped;
+  }, {});
+});
 
 onMounted(() => {
   if (props.movie && props.movie.id) {
@@ -37,47 +59,28 @@ onMounted(() => {
 });
 </script>
 
-
 <template>
-    <div>
-        <div class="max-w-screen-md mx-auto">
-            <div class="mb-10 flex-col justify-center">
-                <div class="bg-white bg-opacity-50 p-6 mb-10">
-                    <p class="text-black text-2xl uppercase font-semibold pb-6 pl-4">Cinema 1</p>
-                    <div class="flex justify-center items-center gap-10">
-                        <div class="bg-black rounded-3xl p-8 uppercase flex flex-col items-center gap-2">
-                            <p class="text-3xl font-semibold">19/4</p>
-                            <p class="text-xl uppercase pb-3">kl 15:00</p>
-                            <p class="text-sm uppercase">seats:</p>
-                            <p class="text-3xl font-semibold">63/63</p>
-                        </div>
-                        <div class="bg-secondary rounded-3xl p-8 uppercase flex flex-col items-center gap-2">
-                            <p class="text-3xl font-semibold">20/4</p>
-                            <p class="text-xl uppercase pb-3">kl 15:00</p>
-                            <p class="text-sm uppercase">seats:</p>
-                            <p class="text-3xl font-semibold">60/63</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="bg-white bg-opacity-50 p-6">
-                    <p class="text-black text-2xl uppercase font-semibold pb-6 pl-4">Cinema 2</p>
-                    <div class="flex justify-center items-center gap-7">
-                        <div class=" bg-black rounded-3xl p-8 uppercase flex flex-col items-center gap-2">
-                            <p class="text-3xl font-semibold">19/4</p>
-                            <p class="text-xl uppercase pb-3">kl 15:00</p>
-                            <p class="text-xs uppercase">seats:</p>
-                            <p class="text-3xl font-semibold">56/56</p>
-
-                        </div>
-                        <div class="bg-secondary rounded-3xl p-8 uppercase flex flex-col items-center gap-2">
-                            <p class="text-3xl font-semibold">20/4</p>
-                            <p class="text-xl uppercase pb-3">kl 15:00</p>
-                            <p class="text-sm uppercase">seats:</p>
-                            <p class="text-3xl font-semibold">42/56</p>
-                        </div>
-                    </div>
-                </div>
+  <div>
+    <div class="max-w-screen-md mx-auto">
+      <div class="mb-10 flex-col justify-center">
+        <div class="bg-white bg-opacity-50 p-6 mb-10">
+          <div v-if="schedules.length === 0" class="text-center">
+            <p>No schedules available for this movie.</p>
+          </div>
+          <div v-for="(cinemaSchedules, cinemaName) in groupedSchedules" :key="cinemaName">
+            <p class="text-black text-2xl uppercase font-semibold pb-6 pl-4">{{ cinemaName }}</p>
+            <div class="flex justify-center items-center gap-10">
+              <div v-for="(schedule, index) in cinemaSchedules.slice(0, 2)" :key="index"
+                   class="bg-secondary rounded-3xl p-8 uppercase flex flex-col items-center gap-2">
+                <p class="text-3xl font-semibold">{{ formatDate(schedule.localDateTime) }}</p>
+                <p class="text-xl uppercase pb-3">{{ formatTime(schedule.localDateTime) }}</p>
+                <p class="text-sm uppercase">seats:</p>
+                <p class="text-3xl font-semibold">{{ schedule.availableSeats }} / {{ schedule.cinemaHall.nrOfSeats }}</p>
+              </div>
             </div>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </template>

--- a/frontend/src/components/Schedules.vue
+++ b/frontend/src/components/Schedules.vue
@@ -83,27 +83,36 @@ async function fetchBookings(scheduleId) {
   }
 }
 
+const sortedArr = computed(() => {
+  return Object.fromEntries(
+    Object.entries(groupedSchedules.value).map(([key, schedules]) => [
+      key,
+      schedules.sort((a, b) => new Date(a.localDateTime) - new Date(b.localDateTime)),
+    ])
+  );
+});
+
 </script>
 
 <template>
   <div>
     <div class="max-w-screen-md mx-auto">
       <div class="mb-10 flex-col justify-center">
-        <div v-for="(cinemaSchedules, cinemaName) in groupedSchedules" :key="cinemaName" class="bg-white bg-opacity-50 p-6 mb-10">
+        <div v-for="(cinemaSchedules, cinemaName) in sortedArr" :key="cinemaName" class="bg-gray-200 bg-opacity-40 pl-10 pr-10 pb-3 pt-3 mb-4">
           <div v-if="schedules.length === 0" class="text-center">
             <p>No schedules available for this movie.</p>
           </div>
           <div>
-            <p class="text-black text-2xl uppercase font-semibold pb-6 pl-4">{{ cinemaName }}</p>
-            <div class="flex justify-center items-center gap-10">
-              <div @click="displaySeat(schedule)" v-for="(schedule, index) in cinemaSchedules.slice(0, 2)" :key="index"
-                   class='bg-secondary rounded-3xl p-6 uppercase flex flex-col items-center gap-2'>
+            <p class="text-black text-2xl uppercase font-semibold pb-2">{{ cinemaName }}</p>
+            <div class="flex flex-wrap justify-between items-center gap-2">
+              <div @click="displaySeat(schedule)" v-for="(schedule, index) in cinemaSchedules" :key="index"
+                   :class="['rounded-3xl','w-[45%]','flex','p-4','uppercase','flex','flex-col','items-center','gap-1',(schedule.cinemaHall.nrOfSeats - bookedSeatsMap.get(schedule.id)) === 0 ? 'bg-secondary' : 'bg-black']">
                 <p class="text-4xl font-semibold">{{ formatDate(schedule.localDateTime) }}</p>
-                <p class="text-xl uppercase pb-3">KL {{ formatTime(schedule.localDateTime) }}</p>
+                <p class="text-xl uppercase ">KL {{ formatTime(schedule.localDateTime) }}</p>
                 <p class="text-sm uppercase">seats:</p>
-                <p class="text-4xl font-semibold">{{ 
-                    schedule.cinemaHall.nrOfSeats - (bookedSeatsMap.get(schedule.id) || 0) 
-                  }}/{{ schedule.cinemaHall.nrOfSeats }}</p>
+                <p class="text-4xl font-semibold">
+                  {{ schedule.cinemaHall.nrOfSeats - (bookedSeatsMap.get(schedule.id)) === 0 ? 'FULL' :  `${schedule.cinemaHall.nrOfSeats - (bookedSeatsMap.get(schedule.id) || 0)}/${schedule.cinemaHall.nrOfSeats }` }}
+                  </p>
               </div>
             </div>
           </div>

--- a/frontend/src/components/Schedules.vue
+++ b/frontend/src/components/Schedules.vue
@@ -98,10 +98,10 @@ const sortedArr = computed(() => {
   <div>
     <div class="max-w-screen-md mx-auto">
       <div class="mb-10 flex-col justify-center">
+        <div class="text-center bg-gray-200 bg-opacity-40 pl-10 pr-10 pb-3 pt-3 mb-4" v-if="schedules.length === 0" >
+          <p>No schedules available</p>
+        </div>
         <div v-for="(cinemaSchedules, cinemaName) in sortedArr" :key="cinemaName" class="bg-gray-200 bg-opacity-40 pl-10 pr-10 pb-3 pt-3 mb-4">
-          <div v-if="schedules.length === 0" class="text-center">
-            <p>No schedules available for this movie.</p>
-          </div>
           <div>
             <p class="text-black text-2xl uppercase font-semibold pb-2">{{ cinemaName }}</p>
             <div class="flex flex-wrap justify-between items-center gap-2">

--- a/frontend/src/components/Seats.vue
+++ b/frontend/src/components/Seats.vue
@@ -1,24 +1,15 @@
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, onMounted, defineEmits } from "vue";
+
 
 const props = defineProps({
-  movie: {
+  schedule: {
     type: Object,
-    required: true
+    required: true 
   }
 });
 
-const cinemaHall = {
-  name: "Hall 1",
-  seatCount: 56
-};
-
-const schedule = {
-  id: "67156dab33fe431712f1cbf3",
-  localDateTime: "2024-10-15T10:18:00",
-  cinemaHall: cinemaHall, 
-  movie: props.movie  
-};
+const emit = defineEmits(['update'])
 
 const user = {
   googleId: "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOJ2ZXJzaW9uIjoxfQ.pOo7q5ZE-XrArgA-nTmbX2SqGLTWtP_qFJs6u8c7rgo",
@@ -26,7 +17,7 @@ const user = {
   email: "ej224sk@student.lnu.se"
 };
 
-const seats = ref(Array.from({ length: cinemaHall.seatCount }, (_, i) => ({
+const seats = ref(Array.from({ length: props.schedule.cinemaHall.nrOfSeats }, (_, i) => ({
   seat: i + 1,
   booked: false,
   chosen: false,
@@ -36,8 +27,8 @@ const isBooking = ref(false);
 
 const fetchBookedSeats = async () => {
   try {
-    const response = await fetch(`http://localhost:9000/schedules/${schedule.id}/booked-seats`);
-    console.log('Schedule ID:', schedule.id);
+    const response = await fetch(`http://localhost:9000/schedules/${props.schedule.id}/booked-seats`);
+    console.log('Schedule ID:', props.schedule.id);
     if (!response.ok) {
       throw new Error("Failed to fetch booked seats");
     }
@@ -68,7 +59,7 @@ const createBooking = async () => {
 
   const booking = {
     userId: user.googleId,
-    schedule: schedule,
+    schedule: props.schedule,
     bookedSeats: chosenSeats
   };
 
@@ -89,6 +80,7 @@ const createBooking = async () => {
     }
 
     alert("Booking successful!");
+    emit('update')
 
     seats.value.forEach(seat => {
       seat.chosen = false;

--- a/frontend/src/components/Seats.vue
+++ b/frontend/src/components/Seats.vue
@@ -138,5 +138,5 @@ onMounted(fetchBookedSeats);
 </template>
 
 <style scoped>
-/* Additional styling can go here */
+
 </style>

--- a/frontend/src/views/MovieProfileView.vue
+++ b/frontend/src/views/MovieProfileView.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, onMounted, computed } from "vue";
-import Seats from "@/components/Seats.vue";
 import Schedules from "@/components/Schedules.vue";
 
 const props = defineProps({
@@ -68,7 +67,6 @@ onMounted(() => {
         <p class="mt-4">{{ movie.description }}</p>
       </div>
       <Schedules :movie="movie" />
-      <Seats :movie="movie" />
     </div>
     <div v-else class="p-4 relative z-2">
       <p>Loading...</p>


### PR DESCRIPTION
Display schedules and seats for a movie.

Move seats into schedule so that the data can go straight from clicked schedule to the displayed seat.
Add schedule prop to seats component to be able to show the seats from that schedule.
Map bookings to the correct schedule in schedules so that the clicked schedule always shows the correct amount of seats left.