### PR TITLE
Add a check to control if user is online on refresh

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -15,6 +15,7 @@ const isLoggedIn = ref(false);
 const isAdmin = ref(false);
 
 onMounted(() => {
+  isLoggedIn.value = localStorage.getItem('userData') !== null;
   window.addEventListener('storage', () => {
     isLoggedIn.value = !isLoggedIn.value;
   });


### PR DESCRIPTION
A bug happened when you refreshed a page while signed in.
The user couldnt logout because the button states were affected by the refresh..