### PR TITLE
Resolve bug - time one hour wrong when scheduling

### DIFF
--- a/frontend/src/components/ScheduleMovie.vue
+++ b/frontend/src/components/ScheduleMovie.vue
@@ -25,7 +25,9 @@ const formatDate = (selectedDate) => {
 };
 
 const convertDateToLocalDateTime = (selectedDate) => {
-    dateTime.value = selectedDate? selectedDate.toISOString().slice(0, 19) : "";
+  dateTime.value = selectedDate
+      ? new Date(selectedDate.getTime() + 60 * 60 * 1000).toISOString().slice(0, 19)
+      : "";
 };
 // Functions to search and handle movie selection
 const searchMovies = async () => {


### PR DESCRIPTION
Correct to UTC +one hour when schedueling a movie.